### PR TITLE
Make fortify.prefix customizable

### DIFF
--- a/src/TwoFactorAuthServiceProvider.php
+++ b/src/TwoFactorAuthServiceProvider.php
@@ -189,7 +189,7 @@ class TwoFactorAuthServiceProvider extends PackageServiceProvider
     {
         config([
             'filament.auth.pages.login' => config('filament-2fa.login'),
-            'fortify.prefix' => 'fortify',
+            'fortify.prefix' => config('fortify.prefix', 'fortify'),
             'fortify.views' => true,
             'fortify.home' => config('filament.home_url'),
             'forms.dark_mode' => config('filament.dark_mode'),


### PR DESCRIPTION
This PR make fortify.prefix customizable !

Curently, developer is stuck to use the "fortify" prefix...

I was face of the need to customize it to something like "auth" but that was not possible.